### PR TITLE
Make face detection optional

### DIFF
--- a/src/cameraproxy.cpp
+++ b/src/cameraproxy.cpp
@@ -745,6 +745,7 @@ void CameraProxy::processViewfinder(libcamera::FrameBuffer *buffer)
     //qDebug() << Q_FUNC_INFO;
 
     Image *i = m_mappedBuffers[buffer].get();
+#ifdef FACE_DETECTION
     QList<QRectF> rects = m_fd.detect(m_viewFinder->currentImage());
 
     if (rects.length() > 0) {
@@ -760,6 +761,9 @@ void CameraProxy::processViewfinder(libcamera::FrameBuffer *buffer)
     }
 
     m_viewFinder->renderImage(buffer, i, m_rects);
+#else
+    m_viewFinder->renderImage(buffer, i);
+#endif
 }
 
 void CameraProxy::processStill(libcamera::FrameBuffer *buffer)

--- a/src/cameraproxy.h
+++ b/src/cameraproxy.h
@@ -153,10 +153,12 @@ private:
 
     std::unordered_map<Control, libcamera::ControlValue> m_controlValues;
 
+#ifdef FACE_DETECTION
     //Face detection
     FaceDetection m_fd;
     QList<QRectF> m_rects;
     uint m_rectDelay = 0;
+#endif
 };
 
 class CaptureEvent : public QEvent

--- a/src/viewfinder.h
+++ b/src/viewfinder.h
@@ -27,6 +27,10 @@ public:
     virtual int setFormat(const libcamera::PixelFormat &format, const QSize &size,
                   const libcamera::ColorSpace &colorSpace,
                   unsigned int stride) = 0;
+#ifdef FACE_DETECTION
     virtual void renderImage(libcamera::FrameBuffer *buffer, Image *image, QList<QRectF>) = 0;
+#else
+    virtual void renderImage(libcamera::FrameBuffer *buffer, Image *image) = 0;
+#endif
     virtual void stop() = 0;
 };

--- a/src/viewfinder2d.cpp
+++ b/src/viewfinder2d.cpp
@@ -66,12 +66,21 @@ int ViewFinder2D::setFormat(const libcamera::PixelFormat &format, const QSize &s
     return 0;
 }
 
+#ifdef FACE_DETECTION
 void ViewFinder2D::renderImage(libcamera::FrameBuffer *buffer, class Image *image, QList<QRectF> rects)
+#else
+void ViewFinder2D::renderImage(libcamera::FrameBuffer *buffer, class Image *image)
+#endif
 {
     size_t size1 = buffer->metadata().planes()[0].bytesused;
     size_t totalSize = 0;
 
+#ifdef FACE_DETECTION
+    qDebug() << "ViewFinder2D - renderImage - Face detection enabled";
     m_rects = rects;
+#else
+    qDebug() << "ViewFinder2D - renderImage - Face detction disabled";
+#endif
     for (uint plane = 0; plane < buffer->metadata().planes().size(); ++plane) {
         totalSize += buffer->metadata().planes()[plane].bytesused;
     }
@@ -141,10 +150,12 @@ void ViewFinder2D::paint(QPainter *painter)
         QPen p(Qt::white);
         p.setWidth(4);
         painter->setPen(p);
+#ifdef FACE_DETECTION
         for (QRectF r: m_rects) {
             QRectF scaled(r.x() * width(), r.y() * height(), r.width() * width(), r.height() * height());
             painter->drawRect(scaled);
         }
+#endif
         return;
     }
 

--- a/src/viewfinder2d.h
+++ b/src/viewfinder2d.h
@@ -26,7 +26,11 @@ public:
     int setFormat(const libcamera::PixelFormat &format, const QSize &size,
                   const libcamera::ColorSpace &colorSpace,
                   unsigned int stride) override;
+#ifdef FACE_DETECTION
     void renderImage(libcamera::FrameBuffer *buffer, class Image *image, QList<QRectF>) override;
+#else
+    void renderImage(libcamera::FrameBuffer *buffer, class Image *image) override;
+#endif
     void stop() override;
 
     QImage currentImage();

--- a/src/viewfinderrenderer.cpp
+++ b/src/viewfinderrenderer.cpp
@@ -170,7 +170,11 @@ void ViewFinderRenderer::stop()
     }
 }
 
+#ifdef FACE_DETECTION
 void ViewFinderRenderer::renderImage(libcamera::FrameBuffer *buffer, Image *image, QList<QRectF>)
+#else
+void ViewFinderRenderer::renderImage(libcamera::FrameBuffer *buffer, Image *image)
+#endif
 {
     qDebug() << Q_FUNC_INFO;
     //if (buffer_)

--- a/src/viewfinderrenderer.h
+++ b/src/viewfinderrenderer.h
@@ -33,7 +33,11 @@ public:
     int setFormat(const libcamera::PixelFormat &format, const QSize &size,
                   const libcamera::ColorSpace &colorSpace,
                   unsigned int stride) override;
+#ifdef FACE_DETECTION
     void renderImage(libcamera::FrameBuffer *buffer, Image *image, QList<QRectF>) override;
+#else
+    void renderImage(libcamera::FrameBuffer *buffer, Image *image) override;
+#endif
     void stop() override;
 
 private:


### PR DESCRIPTION
The current implementation of face detection is WIP, which can lead to a distracting rectangle in the ViewFinder. This commit makes that feature optional at compile time using #defines and disables it by default. It can be enabled by adding FACE_DETECTION to DEFINES in harbour-shutter.pro.